### PR TITLE
feat(telegraf-ds): opinionated telegraf-ds deamonset

### DIFF
--- a/charts/telegraf-ds/templates/_helpers.tpl
+++ b/charts/telegraf-ds/templates/_helpers.tpl
@@ -160,89 +160,6 @@ Create chart name and version as used by the chart label.
 {{- end }}
 {{- end -}}
 
-{{- define "inputs" -}}
-{{- range $inputIdx, $configObject := . -}}
-    {{- range $input, $config := . -}}
-
-    [[inputs.{{- $input }}]]
-    {{- if $config -}}
-    {{- $tp := typeOf $config -}}
-    {{- if eq $tp "map[string]interface {}" -}}
-        {{- range $key, $value := $config -}}
-          {{- $tp := typeOf $value -}}
-          {{- if eq $tp "string" }}
-      {{ $key }} = {{ $value | quote }}
-          {{- end }}
-          {{- if eq $tp "float64" }}
-      {{ $key }} = {{ $value | int64 }}
-          {{- end }}
-          {{- if eq $tp "int" }}
-      {{ $key }} = {{ $value | int64 }}
-          {{- end }}
-          {{- if eq $tp "bool" }}
-      {{ $key }} = {{ $value }}
-          {{- end }}
-          {{- if eq $tp "[]interface {}" }}
-      {{ $key }} = [
-              {{- $numOut := len $value }}
-              {{- $numOut := sub $numOut 1 }}
-              {{- range $b, $val := $value }}
-                {{- $i := int64 $b }}
-                {{- $tp := typeOf $val }}
-                {{- if eq $i $numOut }}
-                  {{- if eq $tp "string" }}
-        {{ $val | quote }}
-                  {{- end }}
-                  {{- if eq $tp "float64" }}
-        {{ $val | int64 }}
-                  {{- end }}
-                {{- else }}
-                  {{- if eq $tp "string" }}
-        {{ $val | quote }},
-                  {{- end}}
-                  {{- if eq $tp "float64" }}
-        {{ $val | int64 }},
-                  {{- end }}
-                {{- end }}
-              {{- end }}
-      ]
-          {{- end }}
-          {{- if eq $tp "map[string]interface {}" }}
-      [[inputs.{{ $input }}.{{ $key }}]]
-            {{- range $k, $v := $value }}
-              {{- $tps := typeOf $v }}
-              {{- if eq $tps "string" }}
-        {{ $k }} = {{ $v }}
-              {{- end }}
-              {{- if eq $tps "[]interface {}"}}
-        {{ $k }} = [
-                {{- $numOut := len $value }}
-                {{- $numOut := sub $numOut 1 }}
-                {{- range $b, $val := $v }}
-                  {{- $i := int64 $b }}
-                  {{- if eq $i $numOut }}
-            {{ $val | quote }}
-                  {{- else }}
-            {{ $val | quote }},
-                  {{- end }}
-                {{- end }}
-        ]
-              {{- end }}
-              {{- if eq $tps "map[string]interface {}"}}
-        [[inputs.{{ $input }}.{{ $key }}.{{ $k }}]]
-                {{- range $foo, $bar := $v }}
-            {{ $foo }} = {{ $bar | quote }}
-                {{- end }}
-              {{- end }}
-            {{- end }}
-          {{- end }}
-          {{- end }}
-    {{- end }}
-    {{- end }}
-    {{ end }}
-{{- end }}
-{{- end -}}
-
 {{- define "processors" -}}
 {{- range $processorIdx, $configObject := . -}}
     {{- range $processor, $config := . -}}
@@ -313,6 +230,131 @@ Create chart name and version as used by the chart label.
               {{- end }}
               {{- if eq $tps "map[string]interface {}"}}
         [processors.{{ $processor }}.{{ $key }}.{{ $k }}]
+                {{- range $foo, $bar := $v }}
+                {{- $tp := typeOf $bar -}}
+                {{- if eq $tp "string" }}
+            {{ $foo }} = {{ $bar | quote }}
+                {{- end }}
+                {{- if eq $tp "int" }}
+            {{ $foo }} = {{ $bar }}
+                {{- end }}
+                {{- if eq $tp "float64" }}
+            {{ $foo }} = {{ int64 $bar }}
+                {{- end }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+    {{- end }}
+    {{- end }}
+    {{ end }}
+{{- end }}
+{{- end -}}
+
+{{- define "aggregators" -}}
+{{- range $aggregatorIdx, $configObject := . -}}
+    {{- range $aggregator, $config := . -}}
+
+    [[aggregators.{{- $aggregator }}]]
+    {{- if $config -}}
+    {{- $tp := typeOf $config -}}
+    {{- if eq $tp "map[string]interface {}" -}}
+        {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "string" }}
+      {{ $key }} = {{ $value | quote }}
+          {{- end }}
+          {{- if eq $tp "float64" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "int" }}
+      {{ $key }} = {{ $value | int64 }}
+          {{- end }}
+          {{- if eq $tp "bool" }}
+      {{ $key }} = {{ $value }}
+          {{- end }}
+          {{- if eq $tp "[]interface {}" }}
+      {{ $key }} = [
+              {{- $numOut := len $value }}
+              {{- $numOut := sub $numOut 1 }}
+              {{- range $b, $val := $value }}
+                {{- $i := int64 $b }}
+                {{- $tp := typeOf $val }}
+                {{- if eq $i $numOut }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }}
+                  {{- end }}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }}
+                  {{- end }}
+                {{- else }}
+                  {{- if eq $tp "string" }}
+        {{ $val | quote }},
+                  {{- end}}
+                  {{- if eq $tp "float64" }}
+        {{ $val | int64 }},
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+      ]
+          {{- end }}
+          {{- end }}
+          {{- range $key, $value := $config -}}
+          {{- $tp := typeOf $value -}}
+          {{- if eq $tp "map[string]interface {}" }}
+      [[aggregators.{{ $aggregator }}.{{ $key }}]]
+            {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "string" }}
+        {{ $k }} = {{ $v | quote }}
+              {{- end }}
+              {{- if eq $tps "[]interface {}"}}
+        {{ $k }} = [
+                {{- $numOut := len $v }}
+                {{- $numOut := sub $numOut 1 }}
+                {{- range $b, $val := $v }}
+                  {{- $i := int64 $b }}
+                  {{- $tv := typeOf $val -}}
+                  {{- if eq $i $numOut }}
+                      {{- if eq $tv "string" }}
+                  {{ $val | quote }}
+                      {{- end }}
+                      {{- if eq $tv "float64" }}
+                        {{- $xval := float64 (int64 $val) -}}
+                        {{- if eq $val $xval -}}
+                  {{ $val | float64 }}.0
+                        {{- else -}}
+                  {{ $val | float64 }}
+                        {{- end -}}
+                      {{- end }}
+                      {{- if eq $tv "int64" }}
+                  {{ $val | int64 }}
+                      {{- end }}
+                  {{- else }}
+                      {{- if eq $tv "string" }}
+                  {{ $val | quote }},
+                      {{- end }}
+                      {{- if eq $tv "float64" }}
+                        {{- $xval := float64 (int64 $val) -}}
+                        {{- if eq $val $xval -}}
+                  {{ $val | float64 }}.0,
+                        {{- else -}}
+                  {{ $val | float64 }},
+                        {{- end -}}
+                      {{- end }}
+                      {{- if eq $tv "int64" }}
+                  {{ $val | int64 }},
+                      {{- end }}
+                  {{- end }}
+                {{- end }}
+        ]
+              {{- end }}
+              {{- end }}
+              {{- range $k, $v := $value }}
+              {{- $tps := typeOf $v }}
+              {{- if eq $tps "map[string]interface {}"}}
+        [aggregators.{{ $aggregator }}.{{ $key }}.{{ $k }}]
                 {{- range $foo, $bar := $v }}
                 {{- $tp := typeOf $bar -}}
                 {{- if eq $tp "string" }}

--- a/charts/telegraf-ds/templates/configmap.yaml
+++ b/charts/telegraf-ds/templates/configmap.yaml
@@ -12,5 +12,29 @@ data:
     {{ template "global_tags" .Values.config.global_tags }}
     {{ template "agent" .Values.config.agent }}
     {{ template "processors" .Values.config.processors }}
+    {{ template "aggregators" .Values.config.aggregators }}
     {{ template "outputs" .Values.config.outputs }}
-    {{ template "inputs" .Values.config.inputs -}}
+
+    [[inputs.diskio]]
+    [[inputs.kernel]]
+    [[inputs.mem]]
+    [[inputs.processes]]
+    [[inputs.swap]]
+    [[inputs.system]]
+
+    [[inputs.cpu]]
+    percpu = true
+    totalcpu = true
+    collect_cpu_time = false
+    report_active = false
+
+    [[inputs.disk]]
+    ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+
+    [[inputs.docker]]
+    endpoint = "unix:///var/run/docker.sock"
+
+    [[inputs.kubernetes]]
+    url = "https://$HOSTIP:10250"
+    bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
+    insecure_skip_verify = true

--- a/charts/telegraf-ds/templates/daemonset.yaml
+++ b/charts/telegraf-ds/templates/daemonset.yaml
@@ -29,6 +29,10 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
+        - name: HOSTIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
 {{ toYaml .Values.env | indent 8 }}
         volumeMounts:
         - name: varrunutmpro

--- a/charts/telegraf-ds/templates/role.yaml
+++ b/charts/telegraf-ds/templates/role.yaml
@@ -1,14 +1,4 @@
 {{- if .Values.rbac.create }}
-# Allow to define extra custom rules
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: influx:telegraf:custom
-  labels:
-    rbac.authorization.k8s.io/aggregate-view-telegraf-custom: "true"
-rules:
-{{ toYaml .Values.rbac.rules | indent 2 }}
----
 # kubernetes_plugin: Give access to stats endpoints
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,8 +7,11 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-view-telegraf-stats: "true"
 rules:
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["nodes/proxy"]
+    resources: ["nodes/stats"]
     verbs: ["get", "watch", "list"]
 ---
 # Define global role with the default system:aggregate-to-view cluster role and the two rules we just created
@@ -28,8 +21,6 @@ metadata:
   name: influx:telegraf
 aggregationRule:
   clusterRoleSelectors:
-    - matchLabels:
-        rbac.authorization.k8s.io/aggregate-view-telegraf-custom: "true"
     - matchLabels:
         rbac.authorization.k8s.io/aggregate-view-telegraf-stats: "true"
     - matchLabels:

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -71,16 +71,16 @@ config:
     hostname: "$HOSTNAME"
     omit_hostname: false
   outputs:
-    - influxdb:
-        urls:
-          - "http://influxdb:8086"
-        database: "telegraf"
-        retention_policy: ""
-        timeout: "5s"
-        username: ""
-        password: ""
-        user_agent: "telegraf"
-        insecure_skip_verify: false
+    # - influxdb:
+    #     urls:
+    #       - "http://influxdb:8086"
+    #     database: "telegraf"
+    #     retention_policy: ""
+    #     timeout: "5s"
+    #     username: ""
+    #     password: ""
+    #     user_agent: "telegraf"
+    #     insecure_skip_verify: false
     - file:
         files:
           - stdout

--- a/charts/telegraf-ds/values.yaml
+++ b/charts/telegraf-ds/values.yaml
@@ -30,10 +30,6 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
-  - name: NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
   - name: "HOST_PROC"
     value: "/rootfs/proc"
   - name: "HOST_SYS"
@@ -47,46 +43,13 @@ tolerations: []
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
-  # Rules for the created rule
-  rules: []
-# When using the prometheus input to scrape all pods you need extra rules set to the ClusterRole to be
-# able to scan the pods for scraping labels. The following rules have been taken from:
-# https://github.com/helm/charts/blob/master/stable/prometheus/templates/server-clusterrole.yaml#L8-L46
-#    - apiGroups:
-#        - ""
-#      resources:
-#        - nodes
-#        - nodes/proxy
-#        - nodes/metrics
-#        - services
-#        - endpoints
-#        - pods
-#        - ingresses
-#        - configmaps
-#      verbs:
-#        - get
-#        - list
-#        - watch
-#    - apiGroups:
-#        - "extensions"
-#      resources:
-#        - ingresses/status
-#        - ingresses
-#      verbs:
-#        - get
-#        - list
-#        - watch
-#    - nonResourceURLs:
-#        - "/metrics"
-#      verbs:
-#        - get
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
-  name:
+  #name:
 
 ## Exposed telegraf configuration
 ## ref: https://docs.influxdata.com/telegraf/v1.13/administration/configuration/
@@ -102,7 +65,7 @@ config:
     flush_interval: "10s"
     flush_jitter: "0s"
     precision: ""
-    debug: false
+    debug: true
     quiet: false
     logfile: ""
     hostname: "$HOSTNAME"
@@ -110,7 +73,7 @@ config:
   outputs:
     - influxdb:
         urls:
-          - "http://influxdb.monitoring:8086"
+          - "http://influxdb:8086"
         database: "telegraf"
         retention_policy: ""
         timeout: "5s"
@@ -118,28 +81,6 @@ config:
         password: ""
         user_agent: "telegraf"
         insecure_skip_verify: false
-  inputs:
-    - cpu:
-        percpu: true
-        totalcpu: true
-        collect_cpu_time: false
-        report_active: false
-    - disk:
-        ignore_fs: ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
-    - diskio:
-    - docker:
-        endpoint: "unix:///var/run/docker.sock"
-        timeout: "5s"
-        perdevice: true
-        total: false
-        docker_label_exclude:
-          - "annotation.kubernetes.io/*"
-    - kernel:
-    - kubernetes:
-        url: "https://kubernetes.default.svc.cluster.local/api/v1/nodes/$NODE_NAME/proxy"
-        bearer_token: "/run/secrets/kubernetes.io/serviceaccount/token"
-        insecure_skip_verify: true
-    - mem:
-    - processes:
-    - swap:
-    - system:
+    - file:
+        files:
+          - stdout


### PR DESCRIPTION
This chart does not allow tweaking the input configuration. It is for
node and Kubernetes monitoring.

Use the `telegraf` chart if you need to configure the inputs